### PR TITLE
fix compile on Linux with GCC

### DIFF
--- a/src/mlx_window.c
+++ b/src/mlx_window.c
@@ -6,7 +6,7 @@
 /*   By: W2wizard <w2wizzard@gmail.com>               +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2022/02/08 01:14:59 by W2wizard      #+#    #+#                 */
-/*   Updated: 2022/06/27 19:55:01 by lde-la-h      ########   odam.nl         */
+/*   Updated: 2022/06/28 12:31:50 by jobvan-d      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,8 +27,8 @@ void mlx_update_matrix(const mlx_t* mlx, int32_t width, int32_t height)
 	 * Incase of this setting we just don't update the widht and height but allow the Z
 	 * to keep updating.
 	 */
-	width = mlx_settings[MLX_STRETCH_IMAGE] ? mlxctx->initialWidth : mlx->width;
-	height = mlx_settings[MLX_STRETCH_IMAGE] ? mlxctx->initialHeight : mlx->height;
+	width = mlx_settings[MLX_STRETCH_IMAGE] ? (int32_t)mlxctx->initialWidth : mlx->width;
+	height = mlx_settings[MLX_STRETCH_IMAGE] ? (int32_t)mlxctx->initialHeight : mlx->height;
 
 	const float matrix[16] = {
 		2.f / width, 0, 0, 0,


### PR DESCRIPTION
Previously it would output the following error:
```
src/mlx_window.c: In function ‘mlx_update_matrix’:
src/mlx_window.c:30:74: error: operand of ‘?:’ changes signedness from ‘int32_t’ {aka ‘int’} to ‘uint32_t’ {aka ‘unsigned int’} due to unsignedness of other operand [-Werror=sign-compare]
   30 |         width = mlx_settings[MLX_STRETCH_IMAGE] ? mlxctx->initialWidth : mlx->width;
      |                                                                          ^~~~~~~~~~
src/mlx_window.c:31:76: error: operand of ‘?:’ changes signedness from ‘int32_t’ {aka ‘int’} to ‘uint32_t’ {aka ‘unsigned int’} due to unsignedness of other operand [-Werror=sign-compare]
   31 |         height = mlx_settings[MLX_STRETCH_IMAGE] ? mlxctx->initialHeight : mlx->height;
      |                                                                            ^~~~~~~~~~~
```
This fix casts an `unsigned int` to an `int`. the maintainer should take into consideration whether this will cause errors as it can overflow when the value is insanely high. Maybe change the types??? idk

System details:
```
uname -a: Linux codam 5.13.0-48-generic #54-Ubuntu SMP Wed Jun 1 20:38:48 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
gcc --version: gcc (Ubuntu 11.2.0-7ubuntu2) 11.2.0
```
Have a nice one!