### PR TITLE
fix compile on Linux (attempt 2)

### DIFF
--- a/include/MLX42/MLX42.h
+++ b/include/MLX42/MLX42.h
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2021/12/28 00:33:01 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/06/29 15:34:58 by lde-la-h      ########   odam.nl         */
+/*   Updated: 2022/07/05 15:12:05 by jobvan-d      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -139,8 +139,8 @@ typedef struct mlx
 {
 	void*		window;
 	void*		context;
-	int32_t		width;
-	int32_t		height;
+	uint32_t	width;
+	uint32_t	height;
 	double		delta_time;
 }	mlx_t;
 
@@ -256,7 +256,7 @@ const char* mlx_strerror(mlx_errno_t val);
  * @param[in] resize Enable window resizing.
  * @returns Ptr to the MLX handle or null on failure.
  */
-mlx_t* mlx_init(int32_t width, int32_t height, const char* title, bool resize);
+mlx_t* mlx_init(uint32_t width, uint32_t height, const char* title, bool resize);
 
 /**
  * Set a setting for MLX42.
@@ -332,7 +332,7 @@ void mlx_focus(mlx_t* mlx);
  * @param[in] width The width of the window.
  * @param[in] height The height of the window.
  */
-void mlx_get_monitor_size(int32_t index, int32_t* width, int32_t* height);
+void mlx_get_monitor_size(int32_t index, uint32_t* width, uint32_t* height);
 
 /**
  * Sets the windows position.
@@ -363,7 +363,7 @@ void mlx_get_window_pos(mlx_t* mlx, int32_t* xpos, int32_t* ypos);
  * @param new_width The new desired width.
  * @param new_height The new desired height.
  */
-void mlx_set_window_size(mlx_t* mlx, int32_t new_width, int32_t new_height);
+void mlx_set_window_size(mlx_t* mlx, uint32_t new_width, uint32_t new_height);
 
 /**
  * Sets the size limits of the specified window.

--- a/include/MLX42/MLX42.h
+++ b/include/MLX42/MLX42.h
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2021/12/28 00:33:01 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/07/05 15:12:05 by jobvan-d      ########   odam.nl         */
+/*   Updated: 2022/07/05 16:15:57 by jobvan-d      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -224,7 +224,7 @@ typedef void (*mlx_keyfunc)(mlx_key_data_t keydata, void* param);
  * @param[in] height The new height of the window. 
  * @param[in] param Additional parameter to pass onto the function.
  */
-typedef void (*mlx_resizefunc)(int32_t width, int32_t height, void* param);
+typedef void (*mlx_resizefunc)(uint32_t width, uint32_t height, void* param);
 
 /**
  * Callback function used to handle window closing which is called when 

--- a/include/MLX42/MLX42_Int.h
+++ b/include/MLX42/MLX42_Int.h
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2021/12/27 23:55:34 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/06/27 14:37:37 by lde-la-h      ########   odam.nl         */
+/*   Updated: 2022/07/05 15:13:18 by jobvan-d      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -242,7 +242,7 @@ bool mlx_freen(int32_t count, ...);
 
 //= OpenGL Functions =//
 
-void mlx_update_matrix(const mlx_t* mlx, int32_t width, int32_t height);
+void mlx_update_matrix(const mlx_t* mlx, uint32_t width, uint32_t height);
 void mlx_draw_instance(mlx_ctx_t* mlx, mlx_image_t* img, mlx_instance_t* instance);
 void mlx_flush_batch(mlx_ctx_t* mlx);
 

--- a/include/MLX42/MLX42_Int.h
+++ b/include/MLX42/MLX42_Int.h
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2021/12/27 23:55:34 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/06/29 19:02:24 by jobvan-d      ########   odam.nl         */
+/*   Updated: 2022/06/27 14:37:37 by lde-la-h      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -179,8 +179,8 @@ typedef struct mlx_ctx
 	GLuint			vbo;
 	GLuint			shaderprogram;
 
-	int32_t			initialWidth;
-	int32_t			initialHeight;
+	uint32_t		initialWidth;
+	uint32_t		initialHeight;
 
 	mlx_list_t*		hooks;
 	mlx_list_t*		images;

--- a/include/MLX42/MLX42_Int.h
+++ b/include/MLX42/MLX42_Int.h
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2021/12/27 23:55:34 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/06/27 14:37:37 by lde-la-h      ########   odam.nl         */
+/*   Updated: 2022/06/29 19:02:24 by jobvan-d      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -179,8 +179,8 @@ typedef struct mlx_ctx
 	GLuint			vbo;
 	GLuint			shaderprogram;
 
-	uint32_t		initialWidth;
-	uint32_t		initialHeight;
+	int32_t			initialWidth;
+	int32_t			initialHeight;
 
 	mlx_list_t*		hooks;
 	mlx_list_t*		images;

--- a/src/mlx_init.c
+++ b/src/mlx_init.c
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2021/12/28 00:24:30 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/06/28 10:10:26 by lde-la-h      ########   odam.nl         */
+/*   Updated: 2022/07/05 15:11:07 by jobvan-d      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -150,10 +150,10 @@ mlx_errno_t mlx_errno = MLX_SUCCESS;
 // Default settings
 int32_t mlx_settings[MLX_SETTINGS_MAX] = {false, false, false, true};
 
-mlx_t* mlx_init(int32_t width, int32_t height, const char* title, bool resize)
+mlx_t* mlx_init(uint32_t width, uint32_t height, const char* title, bool resize)
 {
-	MLX_ASSERT(width > 0, "Window width must be positive");
-	MLX_ASSERT(height > 0, "Window height must be positive");
+	MLX_ASSERT(width > 0, "Window width must be greater than zero");
+	MLX_ASSERT(height > 0, "Window height must be greater than zero");
 	MLX_ASSERT(title, "Window title can't be null");
 
 	bool init;

--- a/src/mlx_loop.c
+++ b/src/mlx_loop.c
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2021/12/28 01:24:36 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/06/27 18:07:04 by lde-la-h      ########   odam.nl         */
+/*   Updated: 2022/07/05 15:05:17 by jobvan-d      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -98,7 +98,7 @@ void mlx_loop(mlx_t* mlx)
 	
 		glClearColor(0.2f, 0.2f, 0.2f, 1.0f);
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-		glfwGetWindowSize(mlx->window, &(mlx->width), &(mlx->height));
+		glfwGetWindowSize(mlx->window, (int*)&(mlx->width), (int*)&(mlx->height));
 
 		if ((mlx->width > 1 || mlx->height > 1))
 			mlx_update_matrix(mlx, mlx->width, mlx->height);

--- a/src/mlx_monitor.c
+++ b/src/mlx_monitor.c
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2022/01/19 17:18:59 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/06/27 20:02:38 by lde-la-h      ########   odam.nl         */
+/*   Updated: 2022/07/05 15:12:43 by jobvan-d      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,7 @@
 
 //= Public =//
 
-void mlx_get_monitor_size(int32_t index, int32_t* width, int32_t* height)
+void mlx_get_monitor_size(int32_t index, uint32_t* width, uint32_t* height)
 {
 	MLX_ASSERT(index < 0, "Index out of bounds");
 	MLX_NONNULL(width);
@@ -31,7 +31,7 @@ void mlx_get_monitor_size(int32_t index, int32_t* width, int32_t* height)
 	const GLFWvidmode* vidmode;
 	if ((vidmode = glfwGetVideoMode(monitors[index])))
 	{
-		*width = vidmode->width;
-		*height = vidmode->height;
+		*width = (uint32_t)vidmode->width;
+		*height = (uint32_t)vidmode->height;
 	}
 }

--- a/src/mlx_window.c
+++ b/src/mlx_window.c
@@ -6,7 +6,7 @@
 /*   By: W2wizard <w2wizzard@gmail.com>               +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2022/02/08 01:14:59 by W2wizard      #+#    #+#                 */
-/*   Updated: 2022/06/29 15:34:25 by lde-la-h      ########   odam.nl         */
+/*   Updated: 2022/07/05 16:03:41 by jobvan-d      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,7 +18,7 @@
  * Recalculate the view projection matrix, used by images for screen pos
  * Reference: https://bit.ly/3KuHOu1 (Matrix View Projection)
  */
-void mlx_update_matrix(const mlx_t* mlx, int32_t width, int32_t height)
+void mlx_update_matrix(const mlx_t* mlx, uint32_t width, uint32_t height)
 {
 	const mlx_ctx_t* mlxctx = mlx->context;
 	const float depth = mlxctx->zdepth;
@@ -47,7 +47,7 @@ static void mlx_resize_callback(GLFWwindow* window, int32_t width, int32_t heigh
 	const mlx_ctx_t* mlxctx = mlx->context;
 
 	if (mlxctx->resize_hook.func)
-		mlxctx->resize_hook.func(width, height, mlxctx->resize_hook.param);
+		mlxctx->resize_hook.func((uint32_t)width, (uint32_t)height, mlxctx->resize_hook.param);
 }
 
 static void mlx_close_callback(GLFWwindow* window)
@@ -106,13 +106,13 @@ void mlx_get_window_pos(mlx_t* mlx, int32_t* xpos, int32_t* ypos)
 	glfwGetWindowPos(mlx->window, xpos, ypos);
 }
 
-void mlx_set_window_size(mlx_t* mlx, int32_t new_width, int32_t new_height)
+void mlx_set_window_size(mlx_t* mlx, uint32_t new_width, uint32_t new_height)
 {
 	MLX_NONNULL(mlx);
 
 	mlx->width = new_width;
 	mlx->height = new_height;
-	glfwSetWindowSize(mlx->window, new_width, new_height);
+	glfwSetWindowSize(mlx->window, (int)new_width, (int)new_height);
 }
 
 void mlx_set_window_limit(mlx_t* mlx, int32_t min_w, int32_t min_h, int32_t max_w, int32_t max_h)


### PR DESCRIPTION
I fixed it by changing the type to `int32_t`, instead of the suggested `uint32_t`, as `glfwGetWindowSize(GLFWwindow* window, int* width, int* height);` uses signed `int`s, therefore it seems to it makes more sense to change it to an `int32_t`. Plus less things to change to the codebase. Cheers!

(See also #36)