### PR TITLE
Added glfwWindowHint() that was deleted last commit

### DIFF
--- a/src/mlx_init.c
+++ b/src/mlx_init.c
@@ -176,6 +176,7 @@ mlx_t* mlx_init(int32_t width, int32_t height, const char* title, bool resize)
 	glfwWindowHint(GLFW_MAXIMIZED, mlx_settings[MLX_MAXIMIZED]);
 	glfwWindowHint(GLFW_DECORATED, mlx_settings[MLX_DECORATED]);
 	glfwWindowHint(GLFW_VISIBLE, !mlx_settings[MLX_HEADLESS]);
+	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 #ifdef __APPLE__
 	glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
 #endif


### PR DESCRIPTION
Added `glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);`. MLX42 does not run otherwise. Tested it on my cub3d project, but maybe you had a reason to delete it.