### PR TITLE
fixed xpm deallocation and switched from int to double for mlx_get_time (more precision)

### DIFF
--- a/include/MLX42/MLX42.h
+++ b/include/MLX42/MLX42.h
@@ -314,7 +314,7 @@ void mlx_terminate(mlx_t* mlx);
  * 
  * @return The amount of time elapsed in seconds.
  */
-int32_t mlx_get_time(void);
+double mlx_get_time(void);
 
 //= Window/Monitor Functions
 

--- a/src/textures/mlx_xpm42.c
+++ b/src/textures/mlx_xpm42.c
@@ -203,5 +203,6 @@ xpm_t* mlx_load_xpm42(const char* path)
 void mlx_delete_xpm42(xpm_t* xpm)
 {
 	MLX_NONNULL(xpm);
+	free(xpm->texture.pixels);
 	free(xpm);
 }

--- a/src/utils/mlx_utils.c
+++ b/src/utils/mlx_utils.c
@@ -118,7 +118,7 @@ uint32_t mlx_rgba_to_mono(uint32_t color)
 
 //= Public =//
 
-int32_t mlx_get_time(void)
+double mlx_get_time(void)
 {
 	return (glfwGetTime());
 }


### PR DESCRIPTION
it seems that the mlx_delete_xpm42 triggers a memory leak by not deallocating the uint8_t pixel array, also the glfw function returns a double, so we get less precision if we cast it to an int.