### PR TITLE
Typos and documentation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
     </div>
 </div>
 
-MLX42 is a performant, easy to use, cross-platform, minimal windowin graphics library to create graphical applications without having to work directly with the native windowing framework of the given operating system.
+MLX42 is a performant, easy to use, cross-platform, minimal windowing graphics library to create graphical applications without having to work directly with the native windowing framework of the given operating system.
 
 It provides primitive tools to draw textures onto the window as well as well as modifying them at runtime as they get displayed on the window.
 
@@ -37,10 +37,10 @@ No more guessing and searching how something functions or is supposed to work.
 
 ## Performance 🚀
 
-It is build on OpenGL and uses batched rendering to speed up the rendering process compared to other libraries.
+It is built on OpenGL and uses batched rendering to speed up the rendering process compared to other libraries.
 
 ## Open source && Community driven 🌐
-This project is being actively maintained by Codam as well as students from the 42 Network. This gives students the direct oppertunity to learn more about the library itself as well as fix any potential bugs instead of merely accepting them.
+This project is being actively maintained by Codam as well as students from the 42 Network. This gives students the direct opportunity to learn more about the library itself as well as fix any potential bugs instead of merely accepting them.
 
 ---
 
@@ -67,12 +67,12 @@ Overall the building of this project is as follows for ALL systems. As long as C
 ## For MacOS:
 
 For MacOS you need to use the following flags to compile your program with the library
-in order to link the program with the right frameworks:
+in order to link the program with the correct frameworks:
 ```bash
 -framework Cocoa -framework OpenGL -framework IOKit
 ```
 
-Normally if you simply installed / build `glfw` from source or already have it installed
+Normally if you simply installed / built `glfw` from source or already have it installed
 the compilation should be:
 ```bash
 ➜  ~ gcc main.c ... libmlx42.a -Iinclude -lglfw
@@ -90,7 +90,7 @@ the compilation should be:
 
 #### MacOS Security:
 
-When running your program in MacOS it may complain, because with Macs you just gotta think different.
+When running your program in MacOS it may complain, because with Macs you just gotta think differently.
 In case of any security warnings or MacOS telling you it can't verify the author/developer, go to ```Settings > Security & Privacy```.
 
 There will be a pop-up at the bottom telling you that an application tried to run, click the option to let it run.
@@ -162,26 +162,26 @@ and they might not even show up in the list until the first time you start the a
 
 ## For Windows:
 
-We highly recommend you simply use [WSL2](#for-windows-with-windows-subsystem-for-linux-2-wsl2) to make this as non-painful as possible.
-However if you insist on building for windows natively than all you need in terms of dependencies is:
+We highly recommend you simply use [WSL2](#for-windows-with-windows-subsystem-for-linux-2-wsl2) to make this as painless as possible.
+However if you insist on building for windows natively then all you need in terms of dependencies is:
 
 - [CMake](https://cmake.org/download/)
 - [GLFW](https://www.glfw.org/download.html)
 
 Once you have all the dependencies correctly installed `CMake` will generate
 the visual studio project files. Simply build it and once you have a `.lib` file
-move them to you actual project and install them as you would with any other library.
+move them to your actual project and install them as you would with any other library.
 
 Just in case here's a [video](https://youtu.be/or1dAmUO8k0?t=494) showing you how this can be done. Conveniently this video also covers how you can link `glfw`.
 
-Of course its up to you to make sure that the code you write is portable. Things that exist on `Unix` don't necessarily exist on `Win32`.
+Of course it's up to you to make sure that the code you write is portable. Things that exist on `Unix` don't necessarily exist on `Win32`.
 
 ## Download and build - MLX42
 
 ```bash 
 ➜  ~ git clone https://github.com/codam-coding-college/MLX42.git
 ➜  ~ cd MLX42
-➜  ~ cmake -B build # build here refers to the folder where its outputed.
+➜  ~ cmake -B build # build here refers to the outputfolder.
 ➜  ~ cmake --build build -j4 # or do make -C build -j4
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,7 @@ Overall the building of this project is as follows for ALL systems. As long as C
 
 1. [Download and build MLX42](#download-and-build---mlx42) 
 
-	In case of any errors CMake will notify you if you're missing any dependencies.
-	You should make sure that the system has [glfw](https://github.com/glfw/glfw) installed!
-	Either ask your local sysadmin to install it or do it yourself via `apt` or `brew`.
+	In case your system doesn't have [glfw](https://github.com/glfw/glfw) installed cmake will detect this and install it for you.
 
 2. Compile your program with the library:
 	- For: [MacOS](#for-macos)

--- a/docs/42.md
+++ b/docs/42.md
@@ -19,7 +19,7 @@ See copyright and license notice in the root project for more information.
 # Foreword
 If you're considering allowing the use of MLX42 in your campus and wondering why you should do it, how it should work, and what it will take to get it working, then you're in the right place!
 
-MLX42 has been battle-tested multiple times at hackathons and other campuses and has received over 500+ commits since 2021. All students share the same sentiment: they enjoy using the library, but it's not too easy to finish the projects. During that time, many bugs, leaks, and segfaults have been fixed.
+MLX42 has been battle-tested multiple times at hackathons and other campuses and has received over 500 commits since 2021. All students share the same sentiment: they enjoy using the library, but it's not too easy to finish the projects. During that time, many bugs, leaks, and segfaults have been fixed.
 
 It addresses one of the main problems at 42, which is that although it is a tech school, it does not provide its students with well-maintained tools to improve their education. All a campus wants is to give its students the best they can.
 
@@ -35,7 +35,7 @@ The miniLibX has many problems that have been around for almost 10+ years:
 
 - `Poor execution`: There are multiple versions: OpenGL, Swift, and X11. Instead of becoming better with each new iteration, they stay the same with no real improvement. It should be future-proof and not dependent on a specific platform.
 
-- `Not cross-platform`: Students constantly encounter the same problem: in school, they work with MacOS, but at home they use Linux. Or they write their project on Linux, but want to show it to their parents using Windows or MacOS. At each point, miniLibX fails to fill that gap. The pandemic in 2019 showed just how much students struggled to evaluate each other using different machines and versions.
+- `Not cross-platform`: Students constantly encounter the same problem: at school they work with MacOS, but at home they use Linux. Or they write their project on Linux, but want to show it to their parents using Windows or MacOS. At each point, miniLibX fails to fill that gap. The pandemic in 2019 showed just how much students struggled to evaluate each other using different machines and versions.
 
 ---
 
@@ -80,7 +80,7 @@ In the `tools` folder, there is a python script that converts XPM3 to XPM42. XPM
 
 ### How can I migrate? What is necessary to change?
 
-Migrating to MLX42 is easy and requires minimal effort, it just has 2 dependencies in order to work.
+Migrating to MLX42 is easy and requires minimal effort, it has just 2 dependencies in order to work.
 
 #### Dependencies
 - [CMake: >= 3.18.0](https://cmake.org/download/)
@@ -98,7 +98,7 @@ There is not much else to do besides these steps. It is a straightforward replac
 
 ## F.A.Q
 
-Q: **_"It has too many features! I think students should do some of them themselves..."_**
+Q: **_"It has too many features! I think students should implement some of them themselves..."_**
 
 A: I can agree that there may be some features that do too much for the students. However, this can be fixed simply by banning the usage of these functions or removing them from the library.
 
@@ -108,9 +108,9 @@ Either way, the majority of additional functions are just GLFW wrappers to enabl
 
 Q: **_"The `mlx_put_pixel` works too well..."_**
 
-A: Rather than purposely sabotaging the library to make a point, I deemed it necessary that the library simply work. By default, this function is already banned by all subjects, and the main idea was to force students to use images.
+A: Rather than purposefully sabotaging the library to make a point, I deemed it necessary that the library simply works. By default, this function is already banned by all subjects, and the main idea was to force students to use images.
 
-In MLX42, it always starts with an image, and students are forced to face images no matter what. They still face the same learning curve of how to modify the buffer of an image and learn the concept of bit shifting one way or another.
+In MLX42 it always starts with an image, and students are forced to face images no matter what. They still face the same learning curve of how to modify the buffer of an image and learn the concept of bit shifting one way or another.
 
 Our proposal is to allow its use in the first three graphics projects (fract-ol, fdf, so_long) and later ban it for the remaining ones (Cub3D, MiniRT), so students can become familiar with it and then need to explore its workings.
 
@@ -134,7 +134,7 @@ It is not taking away from the learning experience, it's just shifting a functio
 
 Q: **_"OpenGL? Isn't that a bit old by now?"_**
 
-A: Is OpenGL old? Sure. But in the end, students don't care. You could argue that it's less future-proof and that Vulkan should be used instead. But ask yourself, does one need a artillery cannon to hunt for a rabbit in a forest? If your answer is no, then why does one need Vulkan to render a bunch of quads on a window?
+A: Is OpenGL old? Sure. But in the end, students don't care. You could argue that it's less future-proof and that Vulkan should be used instead. But ask yourself, does one need an artillery cannon to hunt for a rabbit in a forest? If your answer is no, then why does one need Vulkan to render a bunch of quads on a window?
 
 OpenGL is easy to learn, widely supported and it could be argued that it's actually useful for students who are interested in graphics. Anyway, if one day Vulkan is required, a branch and PR can be created and merged!
 
@@ -146,11 +146,11 @@ Here is the equivalent in [OpenGL](https://learnopengl.com/code_viewer_gh.php?co
 
 Q: **_"CMake? Won't that confuse them?"_**
 
-A: It is 2 simple commands that are described in the README.
+A: It is 2 simple commands that are described in the README, and it's a good opportunity to learn a new way to build your projects.
 
 ---
 
 Q: **_"Who will maintain MLX42? How long can this be guaranteed?"_**
 
-A: Currently it is being maintained by `lde-la-h` (W2Wizard). However commits from the 42 Pedago or really anyone are very much welcomed.
+A: Currently it is being maintained by `lde-la-h` (W2Wizard). However commits from the 42 Pedago or really anyone are very much welcome.
 I myself have been taking care of it since the 1st of January 2021 and aim to continue to support it until I can't.


### PR DESCRIPTION
I had some time today, so I scanned the new documentation for typos and fixed those, I also updated the build instruction to reflect that cmake now automatically installs glfw if it's not already installed.