### PR TITLE
Fix README code example compile error

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ static mlx_image_t* img;
 
 void hook(void* param)
 {
-	const mlx_t* mlx = param;
+	mlx_t* mlx = param;
 
 	if (mlx_is_key_down(mlx, MLX_KEY_ESCAPE))
 		mlx_close_window(mlx);


### PR DESCRIPTION
Fixes the following compiler warning in the code example "warning: passing 'const mlx_t *' (aka 'const struct mlx *') to parameter of type 'mlx_t *'"

It could as well be changed to `mlx_t* const mlx = param;` to make it a constant pointer instead of a pointer to constant.
I guess without is better to prevent some confusion, pointers are hard enough!