### PR TITLE
Fix typo

### DIFF
--- a/include/MLX42/MLX42.h
+++ b/include/MLX42/MLX42.h
@@ -18,7 +18,7 @@
  * 
  * It's a much more up-to-date alternative to the miniLibX which has been
  * extensively proven to be fragile, unmaintained, deprecated and just
- * plain painfully bad to work with. Also it's code quality is dubious.
+ * plain painfully bad to work with. Also its code quality is dubious.
  * 
  * Some structs contain potential void* which are to be ignored as they 
  * simply represent points of abstraction to the hidden internal header.


### PR DESCRIPTION
`its` instead of `it's` in the sentence `it's code quality ...`